### PR TITLE
Update windows

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,4 +1,9 @@
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main, staging, trying]
+    tags:
+      - "v*.*.*"
 
 name: Verify
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -54,27 +54,6 @@ jobs:
         with:
           command: test
 
-  test_android:
-    name: Test Android
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install Cross
-        run: |
-          CROSS_URL=https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-gnu.tar.gz
-          mkdir -p "$HOME/.bin"
-          curl -sfSL --retry-delay 10 --retry 5 "${CROSS_URL}" | tar zxf - -C "$HOME/.bin"
-          echo "$HOME/.bin" >> $GITHUB_PATH
-      - name: Run cross test
-        run: cross test --target aarch64-linux-android
-
   build_misc:
     name: Build miscellaneous systems
     strategy:
@@ -83,6 +62,7 @@ jobs:
           - x86_64-sun-solaris
           - x86_64-unknown-netbsd
           - x86_64-unknown-freebsd
+          - aarch64-linux-android
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -95,7 +75,7 @@ jobs:
           override: true
       - name: Install Cross
         run: |
-          CROSS_URL=https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-gnu.tar.gz
+          CROSS_URL=https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz
           mkdir -p "$HOME/.bin"
           curl -sfSL --retry-delay 10 --retry 5 "${CROSS_URL}" | tar zxf - -C "$HOME/.bin"
           echo "$HOME/.bin" >> $GITHUB_PATH

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -59,7 +59,6 @@ jobs:
     strategy:
       matrix:
         target:
-          - x86_64-sun-solaris
           - x86_64-unknown-netbsd
           - x86_64-unknown-freebsd
           - aarch64-linux-android

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ description = "A cross-platform library for simple advisory file locking."
 keywords = ["file-guard", "file", "lock", "fcntl", "LockFile"]
 edition = "2021"
 
-[dependencies]
-cfg-if = "1.0.0"
-
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.109"
 
@@ -19,4 +16,4 @@ libc = "0.2.109"
 winapi = { version = "0.3.9", features = ["winerror", "minwinbase", "minwindef", "fileapi"] }
 
 [dev-dependencies]
-vmap = "0.5"
+vmap = "0.6"

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ and [`.try_upgrade()`] methods.
 use file_guard::Lock;
 use std::fs::OpenOptions;
 
-let file = OpenOptions::new()
+let mut file = OpenOptions::new()
     .read(true)
     .write(true)
     .create(true)
     .open("example-lock")?;
 
-let lock = file_guard::lock(&file, Lock::Exclusive, 0, 1)?;
+let mut lock = file_guard::lock(&mut file, Lock::Exclusive, 0, 1)?;
+write_to_file(&mut lock)?;
 // the lock will be unlocked when it goes out of scope
 ```
 
@@ -68,7 +69,7 @@ let t = Thing {
 // both locks will be unlocked when t goes out of scope
 ```
 
-Anything that can `Deref` to a `File` can be used with the [`FileGuard`].
+Anything that can `Deref` or `DerefMut` to a `File` can be used with the [`FileGuard`].
 This works with `Rc<File>`:
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ be done safely and atomically. To use this feature, the
 [`file_guard::os::unix::FileGuardExt`] may `use`ed, enabling the [`.upgrade()`]
 and [`.try_upgrade()`] methods.
 
+Note that on Windows, the file must be open with write permissions to lock it.
 
 # Examples
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 //! [`file_guard::os::unix::FileGuardExt`] may `use`ed, enabling the [`.upgrade()`]
 //! and [`.try_upgrade()`] methods.
 //!
+//! Note that on Windows, the file must be open with write permissions to lock it.
+//!
 //! # Examples
 //!
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,15 @@
 //! use std::fs::OpenOptions;
 //!
 //! # fn main() -> std::io::Result<()> {
-//! let file = OpenOptions::new()
+//! let mut file = OpenOptions::new()
 //!     .read(true)
 //!     .write(true)
 //!     .create(true)
 //!     .open("example-lock")?;
 //!
-//! let lock = file_guard::lock(&file, Lock::Exclusive, 0, 1)?;
+//! let mut lock = file_guard::lock(&mut file, Lock::Exclusive, 0, 1)?;
+//! write_to_file(&mut lock)?;
+//! # fn write_to_file(f: &mut std::fs::File) -> std::io::Result<()> { Ok(()) }
 //! // the lock will be unlocked when it goes out of scope
 //! # Ok(())
 //! # }
@@ -67,7 +69,7 @@
 //! # }
 //! ```
 //!
-//! Anything that can `Deref` to a `File` can be used with the [`FileGuard`]
+//! Anything that can `Deref` or `DerefMut` to a `File` can be used with the [`FileGuard`]
 //! (i.e. `Rc<File>`):
 //!
 //! ```
@@ -111,7 +113,7 @@
 
 use std::fs::File;
 use std::io::ErrorKind;
-use std::ops::{Deref, Range};
+use std::ops::{Deref, DerefMut, Range};
 use std::{fmt, io};
 
 pub mod os;
@@ -357,6 +359,15 @@ where
 
     fn deref(&self) -> &T {
         &self.file
+    }
+}
+
+impl<T> DerefMut for FileGuard<T>
+where
+    T: DerefMut<Target = File>,
+{
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.file
     }
 }
 

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,13 +1,13 @@
 //! Provides low-level support operations for file locking.
-cfg_if::cfg_if! {
-    if #[cfg(windows)] {
-        pub mod windows;
-        pub use self::windows::{raw_file_lock, raw_file_downgrade};
-    } else if #[cfg(unix)] {
-        #[macro_use]
-        pub mod unix;
-        pub use self::unix::{raw_file_lock, raw_file_downgrade};
-    } else {
-        // Unknown target_family
-    }
-}
+#[cfg(windows)]
+pub mod windows;
+
+#[cfg(windows)]
+pub use self::windows::{raw_file_lock, raw_file_downgrade};
+
+#[cfg(unix)]
+#[macro_use]
+pub mod unix;
+
+#[cfg(unix)]
+pub use self::unix::{raw_file_lock, raw_file_downgrade};

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -9,6 +9,7 @@ use winapi::shared::minwindef::DWORD;
 use winapi::shared::winerror::ERROR_LOCK_VIOLATION;
 use winapi::um::fileapi::{LockFileEx, UnlockFileEx};
 use winapi::um::minwinbase::{LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, OVERLAPPED};
+use winapi::um::winnt::HANDLE;
 
 use crate::{FileGuard, Lock};
 
@@ -30,7 +31,7 @@ pub unsafe fn raw_file_lock(
     }
 
     let mut ov: OVERLAPPED = MaybeUninit::zeroed().assume_init();
-    let mut s = ov.u.s_mut();
+    let s = ov.u.s_mut();
     s.Offset = (off & 0xffffffff) as DWORD;
     s.OffsetHigh = (off >> 16 >> 16) as DWORD;
 
@@ -42,9 +43,9 @@ pub unsafe fn raw_file_lock(
         if lock == Lock::Exclusive {
             flags |= LOCKFILE_EXCLUSIVE_LOCK;
         }
-        LockFileEx(f.as_raw_handle(), flags, 0, lenlow, lenhigh, &mut ov)
+        LockFileEx(f.as_raw_handle() as HANDLE, flags, 0, lenlow, lenhigh, &mut ov)
     } else {
-        UnlockFileEx(f.as_raw_handle(), 0, lenlow, lenhigh, &mut ov)
+        UnlockFileEx(f.as_raw_handle() as HANDLE, 0, lenlow, lenhigh, &mut ov)
     };
 
     if rc == 0 {


### PR DESCRIPTION
I've not been able to reproduce the error reported in #4 , but from looking at the error, it seems to be a type difference between functions in the winapi. I've cast the `as_raw_handle()` calls to a `HANDLE` value. Both approaches have worked on my Windows 11 machine as well as CI testing, but hopefully this helps with the issue.

This also addresses #3 and #2 .